### PR TITLE
Changes to make sure statsample works with gsl-nmatrix. Will work smoothly with rb-gsl too.

### DIFF
--- a/lib/statsample/factor.rb
+++ b/lib/statsample/factor.rb
@@ -34,7 +34,7 @@ module Statsample
     #   matrix is not appropriate for factor analysis."
     # 
     def self.anti_image_covariance_matrix(matrix)
-      s2=Matrix.diag(*(matrix.inverse.diagonal)).inverse
+      s2=Matrix.diagonal(*(matrix.inverse.diagonal)).inverse
       aicm=(s2)*matrix.inverse*(s2)
       aicm.extend(Statsample::CovariateMatrix)
       aicm.fields=matrix.fields if matrix.respond_to? :fields
@@ -42,13 +42,12 @@ module Statsample
     end
     def self.anti_image_correlation_matrix(matrix)
       matrix=matrix.to_matrix
-      s=Matrix.diag(*(matrix.inverse.diagonal)).sqrt.inverse
+      s=Matrix.diagonal(*(matrix.inverse.diagonal)).sqrt.inverse
       aicm=s*matrix.inverse*s
       
       aicm.extend(Statsample::CovariateMatrix)
       aicm.fields=matrix.fields if matrix.respond_to? :fields
       aicm
-      
     end
       
     # Kaiser-Meyer-Olkin measure of sampling adequacy for correlation matrix.
@@ -101,6 +100,5 @@ module Statsample
       end
       sum_r.quo(sum_r+sum_q)
     end
-    
   end
 end

--- a/lib/statsample/factor/map.rb
+++ b/lib/statsample/factor/map.rb
@@ -75,7 +75,8 @@ module Statsample
         
         (ncol-1).times do |m|
           puts "MAP:Eigenvalue #{m+1}" if $DEBUG
-          a=loadings[0..(loadings.row_size-1),0..m]
+          a=use_gsl ? loadings[0..(loadings.row_size-1),0..m] : 
+            loadings.minor(0..(loadings.row_size-1),0..m)
           partcov= gsl_m - (a*a.transpose)
           
           d=klass_m.diagonal(*(partcov.diagonal.collect {|v| Math::sqrt(1/v)}))

--- a/lib/statsample/matrix.rb
+++ b/lib/statsample/matrix.rb
@@ -56,6 +56,10 @@ class ::Matrix
     }
     GSL::Matrix[*out]
   end
+
+  def []=(i, j, x)
+    @rows[i][j] = x
+  end
 end
 
 module GSL

--- a/statsample.gemspec
+++ b/statsample.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'reportbuilder', '~> 1.4'
   s.add_runtime_dependency 'minimization', '~> 0.2'
   s.add_runtime_dependency 'dirty-memoize', '~> 0.0.4'
-  s.add_runtime_dependency 'extendmatrix', '~> 0.4'
+  s.add_runtime_dependency 'extendmatrix', '~> 0.3'
   s.add_runtime_dependency 'rserve-client', '~> 0.3'
   s.add_runtime_dependency 'rubyvis', '~> 0.5.0'
   s.add_runtime_dependency 'distribution', '~> 0.7'
@@ -85,5 +85,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.5'
   s.add_development_dependency 'gettext', '~> 3.1'
   s.add_development_dependency 'mocha', '~> 1.1'
-  s.add_development_dependency 'gsl-nmatrix', '~> 1.17'
 end

--- a/statsample.gemspec
+++ b/statsample.gemspec
@@ -71,7 +71,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'reportbuilder', '~> 1.4'
   s.add_runtime_dependency 'minimization', '~> 0.2'
   s.add_runtime_dependency 'dirty-memoize', '~> 0.0.4'
-  s.add_runtime_dependency 'extendmatrix', '~> 0.3'
+  s.add_runtime_dependency 'extendmatrix', '~> 0.4'
   s.add_runtime_dependency 'rserve-client', '~> 0.3'
   s.add_runtime_dependency 'rubyvis', '~> 0.5.0'
   s.add_runtime_dependency 'distribution', '~> 0.7'
@@ -85,5 +85,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'minitest', '~> 5.5'
   s.add_development_dependency 'gettext', '~> 3.1'
   s.add_development_dependency 'mocha', '~> 1.1'
-  # s.add_development_dependency 'gsl-nmatrix', '~> 1.17'
+  s.add_development_dependency 'gsl-nmatrix', '~> 1.17'
 end

--- a/test/test_factor.rb
+++ b/test/test_factor.rb
@@ -141,11 +141,13 @@ class StatsampleFactorTestCase < Minitest::Test
   end
   # Tested with SPSS and R
   def test_pca
+
     a = [2.5, 0.5, 2.2, 1.9, 3.1, 2.3, 2.0, 1.0, 1.5, 1.1].to_scale
     b = [2.4, 0.7, 2.9, 2.2, 3.0, 2.7, 1.6, 1.1, 1.6, 0.9].to_scale
     a.recode! { |c| c - a.mean }
     b.recode! { |c| c - b.mean }
     ds = { 'a' => a, 'b' => b }.to_dataset
+
     cov_matrix = Statsample::Bivariate.covariance_matrix(ds)
     if Statsample.has_gsl?
       pca = Statsample::Factor::PCA.new(cov_matrix, use_gsl: true)
@@ -158,6 +160,8 @@ class StatsampleFactorTestCase < Minitest::Test
   end
 
   def pca_set(pca, _type)
+
+
     expected_eigenvalues = [1.284, 0.0490]
     expected_eigenvalues.each_with_index{|ev, i|
       assert_in_delta(ev, pca.eigenvalues[i], 0.001)


### PR DESCRIPTION
@agarie statsample is now working smoothly with gsl-nmatrix and rb-gsl.

Once that bug in distribution is solved we'll have a statsample that is completely capable of working without GSL :)