### PR TITLE
change DataFrame.to_hash -> .to_h in reliability.rb

### DIFF
--- a/lib/statsample/reliability.rb
+++ b/lib/statsample/reliability.rb
@@ -7,7 +7,7 @@ module Statsample
         ds = ods.reject_values(*Daru::MISSING_VALUES)
         n_items = ds.ncols
         return nil if n_items <= 1
-        s2_items = ds.to_hash.values.inject(0) { |ac,v| 
+        s2_items = ds.to_h.values.inject(0) { |ac,v| 
           ac + v.variance }
         total    = ds.vector_sum
         


### PR DESCRIPTION
I tried "scale analysis" usage in the document. But I could not do it to the end because of an error. Daru :: Dataframe # to_hash seems to have been deleted. I changed #to_hash to #to_h. 
Thank you.