### PR TITLE
Don't define Array#sum if already defined. Fixes #58

### DIFF
--- a/lib/statsample.rb
+++ b/lib/statsample.rb
@@ -54,8 +54,10 @@ class Module
 end
 
 class Array
-  def sum
-    inject(:+)
+  unless method_defined?(:sum)
+    def sum
+      inject(:+)
+    end
   end
 
   def mean


### PR DESCRIPTION
Recent versions of ActiveSupport and Ruby 2.4.1 have added a `#sum` method
to the Enumerable class. Their implementation also accepts a block,
which the version included with StatSample does not.

This change tests to see if `Array#sum` is already defined before
patching.

This fixes issue #58 https://github.com/SciRuby/statsample/issues/58