### PR TITLE
Allow to use daru 0.2.0 or newer

### DIFF
--- a/statsample.gemspec
+++ b/statsample.gemspec
@@ -60,7 +60,7 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
 
-  s.add_runtime_dependency 'daru', '~> 0.1.6'
+  s.add_runtime_dependency 'daru', '>= 0.1.6', '< 0.3.0'
   s.add_runtime_dependency 'spreadsheet', '~> 1.1'
   s.add_runtime_dependency 'reportbuilder', '~> 1.4'
   s.add_runtime_dependency 'minimization', '~> 0.2'


### PR DESCRIPTION
Daru 0.2.0 has been released.
Specs are green, got some issues with 2.0 but looks like this is a repository issue, not changes in this particular PR.